### PR TITLE
Deduplicate frequency candidates and filter out-of-band pairs

### DIFF
--- a/spectral_pipeline/fit.py
+++ b/spectral_pipeline/fit.py
@@ -599,10 +599,13 @@ def process_pair(ds_lf: DataSet, ds_hf: DataSet) -> None:
             if abs(old_f - new_freq_hz) < 20e6:
                 return
         target_list.append((new_freq_hz, None))
-    def _dedup_candidates(candidates: list[tuple[float, Optional[float]]], label: str) -> list[tuple[float, Optional[float]]]:
-        unique: dict[float, tuple[float, Optional[float]]] = {}
+    def _dedup_candidates(
+        candidates: list[tuple[float, Optional[float]]],
+        label: str,
+    ) -> list[tuple[float, Optional[float]]]:
+        unique: dict[tuple[float, Optional[float]], tuple[float, Optional[float]]] = {}
         for f, z in candidates:
-            key = round(f / GHZ, 3)
+            key = (round(f / GHZ, 3), None if z is None else round(z, 3))
             if key not in unique:
                 unique[key] = (f, z)
         removed = len(candidates) - len(unique)


### PR DESCRIPTION
## Summary
- Deduplicate LF/HF frequency candidates using rounding to 3 decimal places and log removed duplicates
- Skip candidate pairs outside allowed LF/HF bands before fitting and log total filtered pairs

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cf9af8a3883308b726e50aa17fc57