### PR TITLE
Track successful pair fits

### DIFF
--- a/spectral_pipeline/fit.py
+++ b/spectral_pipeline/fit.py
@@ -429,7 +429,7 @@ def fit_pair(ds_lf: DataSet, ds_hf: DataSet,
     ), cost
 
 
-def process_pair(ds_lf: DataSet, ds_hf: DataSet) -> None:
+def process_pair(ds_lf: DataSet, ds_hf: DataSet) -> Optional[FittingResult]:
     logger.info("Обработка пары T=%d K, H=%d mT", ds_lf.temp_K, ds_lf.field_mT)
     tau_guess_lf, tau_guess_hf = 3e-10, 3e-11
     t_lf, y_lf = _crop_signal(ds_lf.ts.t, ds_lf.ts.s, tag="LF")
@@ -694,6 +694,7 @@ def process_pair(ds_lf: DataSet, ds_hf: DataSet) -> None:
             best_fit.cost,
         )
         ds_lf.fit = ds_hf.fit = None
+        return None
     else:
         ds_lf.fit = ds_hf.fit = best_fit
         logger.info(
@@ -704,3 +705,4 @@ def process_pair(ds_lf: DataSet, ds_hf: DataSet) -> None:
             best_fit.f2 / GHZ,
             best_fit.cost,
         )
+        return best_fit

--- a/tests/test_success_count.py
+++ b/tests/test_success_count.py
@@ -1,0 +1,53 @@
+import numpy as np
+import logging
+
+from spectral_pipeline import DataSet, TimeSeries, RecordMeta, FittingResult, GHZ
+from spectral_pipeline import cli
+
+
+def _make_ds(tag, root, *, field=1, temp=1):
+    ts = TimeSeries(t=np.linspace(0, 1e-9, 5), s=np.zeros(5), meta=RecordMeta(fs=1e9))
+    return DataSet(field_mT=field, temp_K=temp, tag=tag, ts=ts, root=root)
+
+
+def test_success_count_and_export(monkeypatch, tmp_path, caplog):
+    lf1 = _make_ds("LF", tmp_path, field=1)
+    hf1 = _make_ds("HF", tmp_path, field=1)
+    lf2 = _make_ds("LF", tmp_path, field=2)
+    hf2 = _make_ds("HF", tmp_path, field=2)
+    datasets = [lf1, hf1, lf2, hf2]
+    monkeypatch.setattr(cli, "load_records", lambda root: datasets)
+
+    fit_res = FittingResult(
+        f1=10 * GHZ,
+        f2=40 * GHZ,
+        zeta1=1.0,
+        zeta2=1.0,
+        phi1=0.0,
+        phi2=0.0,
+        A1=1.0,
+        A2=1.0,
+        k_lf=1.0,
+        k_hf=1.0,
+        C_lf=0.0,
+        C_hf=0.0,
+        cost=1.0,
+    )
+
+    def fake_process_pair(ds_lf, ds_hf):
+        if ds_lf is lf1:
+            ds_lf.fit = ds_hf.fit = fit_res
+            return fit_res
+        ds_lf.fit = ds_hf.fit = None
+        return None
+
+    monkeypatch.setattr(cli, "process_pair", fake_process_pair)
+    exported = []
+    monkeypatch.setattr(cli, "export_freq_tables", lambda triples, root, outfile=None: exported.append(triples))
+
+    with caplog.at_level(logging.INFO, logger="spectral_pipeline"):
+        triples = cli.main(str(tmp_path), return_datasets=True, do_plot=False)
+
+    assert len(triples) == 1
+    assert triples[0] == (lf1, hf1)
+    assert exported and exported[0] == triples


### PR DESCRIPTION
## Summary
- return fitting results from `process_pair` and skip rejected fits
- log number of successful pairs and export tables only for them
- add regression test for success counter and export filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d07ca17608330b2c72cd7639484f6