### PR TITLE
Improve HF ESPRIT filtering and fallback

### DIFF
--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,12 @@
+import numpy as np
+from spectral_pipeline.fit import _fallback_peak, GHZ
+
+
+def test_fallback_with_avg_fft():
+    fs = 1e11
+    t = np.arange(400) / fs
+    f0 = 40 * GHZ
+    y = np.cos(2 * np.pi * f0 * t)
+    # Force Burg failure by using too high order
+    f_est = _fallback_peak(t, y, fs, (30 * GHZ, 50 * GHZ), f_rough=0.0, order_burg=512)
+    assert abs(f_est - f0) < 0.5 * GHZ


### PR DESCRIPTION
## Summary
- Relax ESPRIT HF filters and add a second-pass check before invoking fallback
- Extend fallback peak search with averaged FFT method and select strongest candidate
- Cover fallback logic with a dedicated unit test

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d0c1eb9d083308c153abdbc782656