### PR TITLE
Adapt fallback peak to signal length

### DIFF
--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -10,3 +10,31 @@ def test_fallback_with_avg_fft():
     # Force Burg failure by using too high order
     f_est = _fallback_peak(t, y, fs, (30 * GHZ, 50 * GHZ), f_rough=0.0, order_burg=512)
     assert abs(f_est - f0) < 0.5 * GHZ
+
+
+def test_fallback_frequency_changes_with_length():
+    fs = 1e11
+    f0 = 40.3 * GHZ
+
+    t_short = np.arange(400) / fs
+    y_short = np.cos(2 * np.pi * f0 * t_short)
+
+    t_long = np.arange(800) / fs
+    y_long = np.cos(2 * np.pi * f0 * t_long)
+
+    f_short = _fallback_peak(t_short, y_short, fs, (30 * GHZ, 50 * GHZ), f_rough=0.0, order_burg=512)
+    f_long = _fallback_peak(t_long, y_long, fs, (30 * GHZ, 50 * GHZ), f_rough=0.0, order_burg=512)
+
+    assert f_short is not None and f_long is not None
+    assert f_short != f_long
+
+
+def test_fallback_short_signal_returns_none():
+    fs = 1e11
+    f0 = 40.3 * GHZ
+    t = np.arange(20) / fs
+    y = np.cos(2 * np.pi * f0 * t)
+
+    f_est = _fallback_peak(t, y, fs, (30 * GHZ, 50 * GHZ), f_rough=0.0)
+
+    assert f_est is None


### PR DESCRIPTION
## Summary
- Make fallback peak's Welch analysis scale with signal length and handle very short signals gracefully
- Cover variable signal length and short-signal cases in fallback peak tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d1f4df3388330b7bfea3f08a4e033