### PR TITLE
Enhance peak estimation without theoretical guidance

### DIFF
--- a/tests/test_peak_in_band.py
+++ b/tests/test_peak_in_band.py
@@ -1,0 +1,13 @@
+from spectral_pipeline.fit import _peak_in_band, GHZ
+import numpy as np
+
+def test_peak_in_band_fallback_without_theory():
+    fs = 1e11
+    t = np.arange(400) / fs
+    f0 = 10 * GHZ
+    y = np.cos(2 * np.pi * f0 * t)
+    freqs = np.linspace(0, fs / 2, 500)
+    amps = np.zeros_like(freqs)
+    f_est = _peak_in_band(freqs, amps, 8, 12, t=t, y=y, fs=fs)
+    assert f_est is not None
+    assert abs(f_est - f0) < 0.5 * GHZ


### PR DESCRIPTION
## Summary
- Integrate optional time-domain fallback into `_peak_in_band` allowing robust peak detection when theoretical frequencies are absent.
- Add regression test ensuring the new fallback retrieves correct frequencies even with flat FFT spectra.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891fb65cf608330825f9eb99a4dc04a