### PR TITLE
Refine peak search and LF-only processing

### DIFF
--- a/spectral_pipeline/cli.py
+++ b/spectral_pipeline/cli.py
@@ -117,7 +117,7 @@ def main(data_dir: str = '.', *, return_datasets: bool = False,
                 use_lf_only = True
         if use_lf_only or ds_hf is None:
             try:
-                fit = process_lf_only(ds_lf)
+                fit = process_lf_only(ds_lf, ds_hf)
             except Exception as e:
                 logger.error("Ошибка обработки %s: %s", key, e)
             else:

--- a/tests/test_crossing.py
+++ b/tests/test_crossing.py
@@ -49,9 +49,11 @@ def test_ignore_hf_after_crossing(monkeypatch, tmp_path):
         ds_lf.fit = ds_hf.fit = fit_res
         return fit_res
 
-    def fake_process_lf_only(ds_lf):
+    def fake_process_lf_only(ds_lf, ds_hf=None):
         called["lf"] += 1
         ds_lf.fit = fit_res
+        if ds_hf is not None:
+            ds_hf.fit = fit_res
         return fit_res
 
     monkeypatch.setattr(cli, "process_pair", fake_process_pair)


### PR DESCRIPTION
## Summary
- allow up to three range expansions when locating FFT peaks
- set candidate frequency bounds to ±50% of the theoretical value
- rework LF-only processing to detect two tones via ESPRIT, FFT peak search, and fallback fitting
- drop single-tone fitting so LF-only path always models both frequencies together

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891f805f99c833094712f79753de038